### PR TITLE
Fixes paramiko.ssh_exception

### DIFF
--- a/wrds2pg/wrds2pg.py
+++ b/wrds2pg/wrds2pg.py
@@ -23,6 +23,7 @@ def get_process(sas_code, wrds_id=None, fpath=None):
         """Function runs SAS code on WRDS server and
         returns result as pipe on stdout."""
         client.load_system_host_keys()
+        client.set_missing_host_key_policy(paramiko.WarningPolicy())
         client.connect('wrds-cloud.wharton.upenn.edu',
                        username=wrds_id, compress=False)
         command = "qsas -stdio -noterminal"


### PR DESCRIPTION
Error: paramiko.ssh_exception.SSHException: Server 'wrds-cloud...' not found in known_hosts
Fix: allow for unknown hosts with warning

See http://docs.paramiko.org/en/stable/api/client.html#paramiko.client.WarningPolicy