### PR TITLE
Update wrds2pg.py

### DIFF
--- a/wrds2pg/wrds2pg.py
+++ b/wrds2pg/wrds2pg.py
@@ -538,7 +538,7 @@ def wrds_update(table_name, schema, host=os.getenv("PGHOST"), dbname=os.getenv("
                 GRANT SELECT ON "%s"."%s"  TO %s_access""" % (schema, alt_table_name, schema)
             res = process_sql(sql, engine)
 
-        return res
+        return True
 
 def process_sql(sql, engine):
 


### PR DESCRIPTION
return `True` instead of `res`.

when `create_roles=False`, `res` is never assigned, causing
> UnboundLocalError: local variable 'res' referenced before assignment

Reverting to old version that returns `True` instead.