### PR TITLE
ravenpack datetime issue

### DIFF
--- a/wrds2pg/wrds2pg.py
+++ b/wrds2pg/wrds2pg.py
@@ -449,6 +449,7 @@ def wrds_to_pg(table_name, schema, engine, wrds_id=None,
             USING regexp_replace(%s, '%s', '\1 ' )::timestamp""" % (schema, alt_table_name, var, var, rplc_dt_reg)
         with engine.connect() as conn:
             conn.execute(text(sql))
+            conn.commit()
 
     return res
 

--- a/wrds2pg/wrds2pg.py
+++ b/wrds2pg/wrds2pg.py
@@ -439,10 +439,14 @@ def wrds_to_pg(table_name, schema, engine, wrds_id=None,
 
     for var in make_table_data["datetimes"]:
         print("Fixing %s" % var)
+        if schema == "rpa":
+            rplc_dt_reg = "(\d{2}[A-Z]{3}\d{2}):"
+        else:
+            rplc_dt_reg = "(\d{2}[A-Z]{3}\d{4}):"
         sql = r"""
             ALTER TABLE "%s"."%s"
             ALTER %s TYPE timestamp
-            USING regexp_replace(%s, '(\d{2}[A-Z]{3}\d{4}):', '\1 ' )::timestamp""" % (schema, alt_table_name, var, var)
+            USING regexp_replace(%s, '%s', '\1 ' )::timestamp""" % (schema, alt_table_name, var, var, rplc_dt_reg)
         with engine.connect() as conn:
             conn.execute(text(sql))
 


### PR DESCRIPTION
Hi there, not sure if this issue is just with ravenpack, but for sure I haven't seen it before when dealing with comp or crsp:

```
>>> wrds_update(schema="rpa"
...     , table_name="rpa_djpr_equities_2000" 
...     , host="localhost"
...     , dbname="wrds"
...     , wrds_id="qu_jieniu"
...     , fix_missing=True
...     , fix_cr=True
...     , force=True
...     , create_roles=False
...     )
Forcing update based on user request.
Beginning file import at 15:51:07.
Importing data into rpa.rpa_djpr_equities_2000
Completed file import at 15:56:56.
Fixing timestamp_utc
Traceback (most recent call last):
  File "/home/jieniu/.pyenv/versions/3.9.13/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1964, in _exec_single_context
    self.dialect.do_execute(
  File "/home/jieniu/.pyenv/versions/3.9.13/lib/python3.9/site-packages/sqlalchemy/engine/default.py", line 747, in do_execute
    cursor.execute(statement, parameters)
psycopg2.errors.InvalidDatetimeFormat: invalid input syntax for type timestamp: "01JAN00:17:52:28.000000"


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jieniu/.pyenv/versions/3.9.13/lib/python3.9/site-packages/wrds2pg/wrds2pg.py", line 518, in wrds_update
    wrds_to_pg(table_name=table_name, schema=schema, engine=engine, wrds_id=wrds_id,
  File "/home/jieniu/.pyenv/versions/3.9.13/lib/python3.9/site-packages/wrds2pg/wrds2pg.py", line 447, in wrds_to_pg
    conn.execute(text(sql))
  File "/home/jieniu/.pyenv/versions/3.9.13/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1414, in execute
    return meth(
  File "/home/jieniu/.pyenv/versions/3.9.13/lib/python3.9/site-packages/sqlalchemy/sql/elements.py", line 485, in _execute_on_connection
    return connection._execute_clauseelement(
  File "/home/jieniu/.pyenv/versions/3.9.13/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1638, in _execute_clauseelement
    ret = self._execute_context(
  File "/home/jieniu/.pyenv/versions/3.9.13/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1842, in _execute_context
    return self._exec_single_context(
  File "/home/jieniu/.pyenv/versions/3.9.13/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1983, in _exec_single_context
    self._handle_dbapi_exception(
  File "/home/jieniu/.pyenv/versions/3.9.13/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 2325, in _handle_dbapi_exception
    raise sqlalchemy_exception.with_traceback(exc_info[2]) from e
  File "/home/jieniu/.pyenv/versions/3.9.13/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1964, in _exec_single_context
    self.dialect.do_execute(
  File "/home/jieniu/.pyenv/versions/3.9.13/lib/python3.9/site-packages/sqlalchemy/engine/default.py", line 747, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.DataError: (psycopg2.errors.InvalidDatetimeFormat) invalid input syntax for type timestamp: "01JAN00:17:52:28.000000"

[SQL: 
            ALTER TABLE "rpa"."rpa_djpr_equities_2000"
            ALTER timestamp_utc TYPE timestamp
            USING regexp_replace(timestamp_utc, '(\d{2}[A-Z]{3}\d{4}):', '\1 ' )::timestamp]
```

Changed the regex a little bit. Will check if it happens with other datasets when there's a chance. 
