### PR TITLE
wrds_update_csv with last-modified support through mtime

### DIFF
--- a/wrds2pg/__init__.py
+++ b/wrds2pg/__init__.py
@@ -4,4 +4,4 @@ from wrds2pg.wrds2pg import wrds_update, run_file_sql, get_modified_str
 from wrds2pg.wrds2pg import process_sql, get_modified_pq
 from wrds2pg.wrds2pg import make_engine, get_process, wrds_process_to_pg
 from wrds2pg.wrds2pg import wrds_id, set_table_comment, get_table_sql
-from wrds2pg.wrds2pg import wrds_to_parquet, csv_to_pq, wrds_to_csv
+from wrds2pg.wrds2pg import wrds_to_parquet, csv_to_pq, wrds_to_csv, wrds_update_csv

--- a/wrds2pg/wrds2pg.py
+++ b/wrds2pg/wrds2pg.py
@@ -12,6 +12,7 @@ import gzip
 import tempfile
 import pyarrow.parquet as pq
 import pyarrow as pa
+import time
 
 from sqlalchemy.engine import reflection
 from os import getenv

--- a/wrds2pg/wrds2pg.py
+++ b/wrds2pg/wrds2pg.py
@@ -665,8 +665,6 @@ def wrds_to_parquet(table_name, schema, host=os.getenv("PGHOST"),
                     sas_encoding=None, date_format="%Y%m%d", force=False, fpath=None, rpath=None):
 
     data_dir = os.path.expanduser(data_dir)
-    if not os.path.exists(data_dir):
-        os.makedirs(data_dir)
     
     if not sas_schema:
         sas_schema = schema
@@ -732,13 +730,6 @@ def wrds_to_csv(table_name, schema, csv_file=None,
         
           
     if not csv_file:
-         
-        data_dir = os.path.expanduser(data_dir)
-        if not os.path.exists(data_dir):
-            os.makedirs(data_dir)
-        
-        if not alt_table_name:
-            alt_table_name = table_name
         
         schema_dir = Path(data_dir, schema)
     

--- a/wrds2pg/wrds2pg.py
+++ b/wrds2pg/wrds2pg.py
@@ -723,7 +723,7 @@ def wrds_to_csv(table_name, schema, csv_file=None,
                 fix_missing=False, fix_cr=False, drop="", keep="", 
                 obs="", rename="", encoding="utf-8", 
                 sas_schema=None, 
-                sas_encoding=None):
+                sas_encoding=None, force=False, fpath=None, rpath=None):
         
     if not sas_schema:
         sas_schema = schema

--- a/wrds2pg/wrds2pg.py
+++ b/wrds2pg/wrds2pg.py
@@ -678,8 +678,8 @@ def wrds_to_parquet(table_name, schema, host=os.getenv("PGHOST"),
         os.makedirs(schema_dir)
     pq_file = Path(data_dir, schema, table_name).with_suffix('.parquet')
 
-    modified = get_modified_str(table_name, sas_schema, wrds_id, encoding=encoding,
-                                    rpath=rpath)
+    modified = get_modified_str(table_name, sas_schema, wrds_id, encoding=encoding,rpath=rpath)
+    
     if os.path.exists(pq_file):
         pq_modified = get_modified_pq(pq_file)
     else:
@@ -723,7 +723,7 @@ def wrds_to_csv(table_name, schema, csv_file=None,
                 fix_missing=False, fix_cr=False, drop="", keep="", 
                 obs="", rename="", encoding="utf-8", 
                 sas_schema=None, 
-                sas_encoding=None, force=False, fpath=None, rpath=None):
+                sas_encoding=None):
         
     if not sas_schema:
         sas_schema = schema
@@ -737,12 +737,17 @@ def wrds_to_csv(table_name, schema, csv_file=None,
             os.makedirs(schema_dir)
         
         csv_file = Path(data_dir, schema, table_name).with_suffix('.csv.gz')
+        # Extract the date-time part from the modified string
+        modified = get_modified_str(table_name, sas_schema, wrds_id, encoding=encoding,rpath=rpath)
+        date_time_str = modified.split("Last modified: ")[1]
+        print("last modified:"+ date_time_str)
+        # Convert date_time_str to a timestamp
+        modified_time = time.mktime(datetime.strptime(date_time_str, "%m/%d/%Y %H:%M:%S").timetuple())
+    
+        # Update the last-modified timestamp of the CSV file
+        os.utime(csv_file, (modified_time, modified_time))
         
         print("Saving data to " + str(csv_file) + ".")
-        
-        modified = get_modified_str(table_name, sas_schema, wrds_id, encoding=encoding,
-                                    rpath=rpath)
-        print("Last modified " + modified + ".")
 
     p = get_wrds_process(table_name=table_name, 
                          schema=sas_schema, wrds_id=wrds_id,

--- a/wrds2pg/wrds2pg.py
+++ b/wrds2pg/wrds2pg.py
@@ -719,15 +719,39 @@ def wrds_to_parquet(table_name, schema, host=os.getenv("PGHOST"),
     csv_to_pq(csv_file, pq_file, names, dtypes, modified, date_format)
     return True
 
-def wrds_to_csv(table_name, schema, csv_file, 
-                wrds_id=os.getenv("WRDS_ID"), 
+def wrds_to_csv(table_name, schema, csv_file=None, 
+                wrds_id=os.getenv("WRDS_ID"),
+                data_dir=os.getenv("DATA_DIR"),
                 fix_missing=False, fix_cr=False, drop="", keep="", 
                 obs="", rename="", encoding="utf-8", 
                 sas_schema=None, 
                 sas_encoding=None):
-          
+        
     if not sas_schema:
         sas_schema = schema
+        
+          
+    if not csv_file:
+         
+        data_dir = os.path.expanduser(data_dir)
+        if not os.path.exists(data_dir):
+            os.makedirs(data_dir)
+        
+        if not alt_table_name:
+            alt_table_name = table_name
+        
+        schema_dir = Path(data_dir, schema)
+    
+        if not os.path.exists(schema_dir):
+            os.makedirs(schema_dir)
+        
+        csv_file = Path(data_dir, schema, table_name).with_suffix('.csv.gz')
+        
+        print("Saving data to " + str(csv_file) + ".")
+        
+        modified = get_modified_str(table_name, sas_schema, wrds_id, encoding=encoding,
+                                    rpath=rpath)
+        print("Last modified " + modified + ".")
 
     p = get_wrds_process(table_name=table_name, 
                          schema=sas_schema, wrds_id=wrds_id,

--- a/wrds2pg/wrds2pg.py
+++ b/wrds2pg/wrds2pg.py
@@ -13,8 +13,8 @@ import tempfile
 import pyarrow.parquet as pq
 import pyarrow as pa
 import time
-from datetime import datetime
-
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 from sqlalchemy.engine import reflection
 from os import getenv
 
@@ -780,8 +780,12 @@ def wrds_to_csv(table_name, schema, csv_file=None,
         date_time_str = modified.split("Last modified: ")[1]
         # print("last modified:"+ date_time_str)
         
-        # Convert date_time_str to a timestamp
-        modified_time = time.mktime(datetime.strptime(date_time_str, "%m/%d/%Y %H:%M:%S").timetuple())
+        # Convert date_time_str to a datetime object in UTC time zone
+        utc_dt = datetime.strptime(date_time_str, "%m/%d/%Y %H:%M:%S").replace(tzinfo=ZoneInfo("America/Chicago")).astimezone(timezone.utc)
+        # Convert to epoch time
+       
+        # Convert to epoch time
+        modified_time =  utc_dt.timestamp()
     
         
         
@@ -808,8 +812,8 @@ def wrds_to_csv(table_name, schema, csv_file=None,
         
 def get_modified_csv(file_name):
      # Get the last-modified time in seconds since the epoch, convert to date and format as str
-    
-    last_modified = datetime.fromtimestamp(os.path.getmtime(file_name)).strftime("Last modified: %m/%d/%Y %H:%M:%S")
+    utc_dt=datetime.fromtimestamp(os.path.getmtime(file_name))#utc_timestamp=1685112588
+    last_modified = utc_dt.astimezone(ZoneInfo("America/Chicago")).strftime("Last modified: %m/%d/%Y %H:%M:%S")
 
     # Format the datetime object as per the specified format
     # last_modified = last_modified_datetime.strftime("Last modified: %m/%d/%Y %H:%M:%S")

--- a/wrds2pg/wrds2pg.py
+++ b/wrds2pg/wrds2pg.py
@@ -13,6 +13,7 @@ import tempfile
 import pyarrow.parquet as pq
 import pyarrow as pa
 import time
+from datetime import datetime
 
 from sqlalchemy.engine import reflection
 from os import getenv

--- a/wrds2pg/wrds2pg.py
+++ b/wrds2pg/wrds2pg.py
@@ -777,7 +777,7 @@ def wrds_to_csv(table_name, schema, csv_file=None,
         
 def get_modified_csv(file_name):
      # Get the last-modified time in seconds since the epoch
-    last_modified_timestamp = os.path.getmtime(file_path)
+    last_modified_timestamp = os.path.getmtime(file_name)
 
     # Convert it into a datetime object
     last_modified_datetime = datetime.fromtimestamp(last_modified_timestamp)

--- a/wrds2pg/wrds2pg.py
+++ b/wrds2pg/wrds2pg.py
@@ -788,14 +788,12 @@ def wrds_to_csv(table_name, schema, csv_file=None,
         shutil.copyfileobj(p, f)
         
 def get_modified_csv(file_name):
-     # Get the last-modified time in seconds since the epoch
-    last_modified_timestamp = os.path.getmtime(file_name)
-
-    # Convert it into a datetime object
-    last_modified_datetime = datetime.fromtimestamp(last_modified_timestamp)
+     # Get the last-modified time in seconds since the epoch, convert to date and format as str
+    
+    last_modified = datetime.fromtimestamp(os.path.getmtime(file_name)).strftime("Last modified: %m/%d/%Y %H:%M:%S")
 
     # Format the datetime object as per the specified format
-    last_modified = last_modified_datetime.strftime("Last modified: %m/%d/%Y %H:%M:%S")
+    # last_modified = last_modified_datetime.strftime("Last modified: %m/%d/%Y %H:%M:%S")
     
     return last_modified
   

--- a/wrds2pg/wrds2pg.py
+++ b/wrds2pg/wrds2pg.py
@@ -764,8 +764,20 @@ def wrds_to_csv(table_name, schema, csv_file=None,
         # Convert date_time_str to a timestamp
         modified_time = time.mktime(datetime.strptime(date_time_str, "%m/%d/%Y %H:%M:%S").timetuple())
     
+        
+        
+        p = get_wrds_process(table_name=table_name, 
+                         schema=sas_schema, wrds_id=wrds_id,
+                         drop=drop, keep=keep, fix_cr=fix_cr, 
+                         fix_missing=fix_missing, obs=obs, rename=rename,
+                         encoding=encoding, sas_encoding=sas_encoding)
+        with gzip.GzipFile(csv_file, mode='wb') as f:
+            shutil.copyfileobj(p, f)
+        # Get the current time for access time
+        current_time = time.time()    
         # Update the last-modified timestamp of the CSV file
-        os.utime(csv_file, (modified_time, modified_time))
+        os.utime(csv_file, (current_time, modified_time))    
+        return True
 
     p = get_wrds_process(table_name=table_name, 
                          schema=sas_schema, wrds_id=wrds_id,


### PR DESCRIPTION
Resolves #33 

Uses the sas meta data from get_modified_str, which is in Central Time (with day light savings), converted to UTC and written to the mtime of the downloaded *.csv.gz file.

On update, read the mtime of an existing .csv.gz file,  convert it from epoch to central time, and compare with the sas meta data to decide whether there was an update.

Pros:
- does not depend on user's OS or locale setting
- last modified shows the correct time when the data was actually last updated on wrds

Cons:
- last modified no longer shows when the data was downloaded by the user. Hard to substitute with atime or ctime since they do not behave consistently across OS/file systems. Can still check the directory mtime.
